### PR TITLE
Mengganti sumber data API untuk statistik jumlah kasus nasional

### DIFF
--- a/functions/env.json
+++ b/functions/env.json
@@ -1,6 +1,6 @@
 {
     "updateStatistics": {
         "jabarAPI": "https://covid19-public.digitalservice.id/api/v1/rekapitulasi/jabar",
-        "nationalAPI": "https://indonesia-covid-19.mathdro.id/api"
+        "nationalAPI": "https://dekontaminasi.com/api/id/covid19/stats"
     }
 }

--- a/functions/updateStatistics.js
+++ b/functions/updateStatistics.js
@@ -8,7 +8,6 @@ exports.updateStatistics =
     .onRun(async context => {
       let statistics = {
         'updated_at': null,
-        // 'confirmed': {},
         'aktif': {},
         'sembuh': {},
         'meninggal': {},
@@ -61,7 +60,6 @@ async function getNationalStatistics(updatedStatistics) {
         const fatal = data.numbers.fatal;
         const activeCases = infected - (recovered + fatal);
 
-        // updatedStatistics.confirmed.nasional = infected;
         updatedStatistics.aktif.nasional = infected;
         updatedStatistics.sembuh.nasional = recovered;
         updatedStatistics.meninggal.nasional = fatal;

--- a/functions/updateStatistics.js
+++ b/functions/updateStatistics.js
@@ -8,6 +8,7 @@ exports.updateStatistics =
     .onRun(async context => {
       let statistics = {
         'updated_at': null,
+        // 'confirmed': {},
         'aktif': {},
         'sembuh': {},
         'meninggal': {},
@@ -55,9 +56,15 @@ async function getNationalStatistics(updatedStatistics) {
   return axios.get(functions.config().env.updateStatistics.nationalAPI)
     .then(res => {
         const data = res.data;
-        updatedStatistics.aktif.nasional = data.jumlahKasus;
-        updatedStatistics.sembuh.nasional = data.sembuh;
-        updatedStatistics.meninggal.nasional = data.meninggal;
+        const infected = data.numbers.infected;
+        const recovered = data.numbers.recovered;
+        const fatal = data.numbers.fatal;
+        const activeCases = infected - (recovered + fatal);
+
+        // updatedStatistics.confirmed.nasional = infected;
+        updatedStatistics.aktif.nasional = infected;
+        updatedStatistics.sembuh.nasional = recovered;
+        updatedStatistics.meninggal.nasional = fatal;
 
         return updatedStatistics;
     })


### PR DESCRIPTION
Pagi ini terjadi anomali jumlah kasus nasional di API https://indonesia-covid-19.mathdro.id/api
```
{
  "meninggal": 5193,
  "sembuh": 19658,
  "perawatan": 26778,
  "jumlahKasus": 99196
}
```
Padahal ini statistik yang benar dari Dashboard Gugus Tugas:
![image](https://user-images.githubusercontent.com/618412/85812469-ed21b300-b78a-11ea-9db7-c6984aa702ae.png)

### Proposed solution:
Mengganti sumber API nasional ke https://dekontaminasi.com/api/id/covid19/stats
Source: https://github.com/ariya/dekontaminasi Kalau melihat sumber datanya, yang dipakai official dari covid19.go.id

### Note:
Kalau sudah dimerge, minta tolong sekalian di Deploy cloud functionsnya.